### PR TITLE
Support release names

### DIFF
--- a/ankh/cli.py
+++ b/ankh/cli.py
@@ -246,6 +246,7 @@ def main():
             default=os.environ.get("ANKHCONFIG", os.environ.get("HOME", "") + "/.ankh/config"))
     parser.add_argument('--environment', dest='environment', choices=['autoenv', 'production'], help='the environment to use. files from values/{env} and secrets/{env} will be used.')
     parser.add_argument('--profile', dest='profile', choices=['production', 'minikube'], help='the profile to use. files from profiles/{profile} will be used. takes precedence over files used by "environment"')
+    parser.add_argument('--release', dest='release', help='the release name to pass to Helm')
     args = parser.parse_args()
 
     # context commands require no global_config nor any of the optional command-line args.
@@ -331,6 +332,10 @@ def run(base_dir, args):
     if 'profile' not in global_config or not global_config['profile']:
         logger.error("Must provide profile in the config file or on the command line via --profile")
         sys.exit(1)
+
+    # Release is optional on the command line. If present, overrides config. Optional.
+    if args.release:
+        global_config['release'] = args.release
 
     # Helm registry is optional on the command line. If present, overrides config. Required overall.
     if args.helm_registry:

--- a/ankh/helm.py
+++ b/ankh/helm.py
@@ -18,6 +18,7 @@ import os
 import logging
 import subprocess
 import sys
+import yaml
 
 from ankh.utils import explain_something, collapse
 
@@ -207,6 +208,12 @@ def helm_append_chartref(helm, chart):
     helm += [ chartref ]
     return
 
+def helm_append_release(helm, chart, global_config):
+    if 'release' in global_config and global_config['release']:
+        release = global_config['release']
+        helm += [ '--name', release ]
+    return
+
 def helm_template_command(chart, global_config, args):
     helm = [ 'helm', 'template' ]
     helm_append_base(helm, global_config)
@@ -215,5 +222,6 @@ def helm_template_command(chart, global_config, args):
     helm_append_secrets(helm, chart, global_config, args)
     helm_append_values(helm, chart, global_config, args)
     helm_append_profile(helm, chart, global_config, args)
+    helm_append_release(helm, chart, global_config)
     helm_append_chartref(helm, chart)
     return helm

--- a/ankh/utils.py
+++ b/ankh/utils.py
@@ -19,11 +19,14 @@ import logging
 logger = logging.getLogger('ankh')
 
 def command_header(action, global_config):
-    namespace_context = ""
+    namespace_str = ""
     if 'namespace' in global_config:
-        namespace_context = " and namespace \"" + global_config['namespace'] + "\""
-    full_context = "context \"" + global_config['kube_context'] + "\" using environment \"" + global_config['environment'] + "\"" + namespace_context
-    logger.info("%s %s" % (action, full_context))
+        namespace_str = " to namespace \"" + global_config['namespace'] + "\""
+    release_str = ""
+    if 'release' in global_config:
+        release_str = "release \"" + global_config['release'] + "\" with "
+    full_str = release_str + "context \"" + global_config['kube_context'] + "\" using environment \"" + global_config['environment'] + "\"" + namespace_str
+    logger.info("%s %s" % (action, full_str))
     return
 
 


### PR DESCRIPTION
Use Helm's --name feature, towards running multiple logical deployments in the same cluster/namespace.