### PR TITLE
Bugfixes

### DIFF
--- a/src/ankh/cmd/ankh/main.go
+++ b/src/ankh/cmd/ankh/main.go
@@ -222,8 +222,7 @@ func main() {
 					os.Exit(1)
 				}
 
-				config := ctx.AnkhConfig
-				config.CurrentContextName = context
+				ctx.AnkhConfig.CurrentContextName = context
 
 				out, err := yaml.Marshal(ctx.AnkhConfig)
 				check(err)

--- a/src/ankh/kubectl/kubectl.go
+++ b/src/ankh/kubectl/kubectl.go
@@ -19,7 +19,10 @@ func Execute(ctx *ankh.ExecutionContext, act action, input string, ankhFile ankh
 	kubectlArgs := []string{
 		"kubectl", string(act),
 		"--context", ctx.AnkhConfig.CurrentContext.KubeContext,
-		"--namespace", ankhFile.Namespace,
+	}
+
+	if ankhFile.Namespace != "" {
+		kubectlArgs = append(kubectlArgs, []string{"--namespace", ankhFile.Namespace}...)
 	}
 
 	if ctx.KubeConfigPath != "" {
@@ -32,6 +35,10 @@ func Execute(ctx *ankh.ExecutionContext, act action, input string, ankhFile ankh
 
 	kubectlArgs = append(kubectlArgs, "-f", "-")
 	kubectlCmd := exec.Command(kubectlArgs[0], kubectlArgs[1:]...)
+
+	if ctx.Verbose {
+		ctx.Logger.Infof("running kubectl command: %v", kubectlArgs)
+	}
 
 	kubectlStdoutPipe, _ := kubectlCmd.StdoutPipe()
 	kubectlStderrPipe, _ := kubectlCmd.StderrPipe()


### PR DESCRIPTION
- Fix set-context to set the correct variable so it works properly.
- Fix an issue where we'd set the namespace when invoking kubectl, even if it's missing