### PR TITLE
chart-flag: adds --chart flag for apply and template

### DIFF
--- a/src/ankh/ankh.go
+++ b/src/ankh/ankh.go
@@ -14,7 +14,7 @@ import (
 // Captures all of the context required to execute a single iteration of Ankh
 type ExecutionContext struct {
 	AnkhConfig   AnkhConfig
-	AnkhFilePath string
+	AnkhFilePath, Chart string
 
 	Verbose, DryRun, Apply bool
 

--- a/src/ankh/cmd/ankh/main.go
+++ b/src/ankh/cmd/ankh/main.go
@@ -106,6 +106,8 @@ func execute(ctx *ankh.ExecutionContext) {
 
 	if len(rootAnkhFile.Charts) > 0 {
 		executeAnkhFile(rootAnkhFile)
+	} else {
+		ctx.Logger.Warningf("No charts specified inside %s, nothing to do", ctx.AnkhFilePath)
 	}
 }
 
@@ -167,14 +169,16 @@ func main() {
 	}
 
 	app.Command("apply", "Deploy an ankh file to a kubernetes cluster", func(cmd *cli.Cmd) {
-		cmd.Spec = "[-f] [--dry-run]"
+		cmd.Spec = "[-f] [--dry-run] [--chart]"
 
 		ankhFilePath := cmd.StringOpt("f filename", "ankh.yaml", "Config file name")
 		dryRun := cmd.BoolOpt("dry-run", false, "Perform a dry-run and don't actually apply anything to a cluster")
+		chart := cmd.StringOpt("chart", "", "Limits the apply command to only the specified chart")
 
 		cmd.Action = func() {
 			ctx.AnkhFilePath = *ankhFilePath
 			ctx.DryRun = *dryRun
+			ctx.Chart = *chart
 			ctx.Apply = true
 
 			execute(ctx)
@@ -183,12 +187,14 @@ func main() {
 	})
 
 	app.Command("template", "Output the results of templating an ankh file", func(cmd *cli.Cmd) {
-		cmd.Spec = "[-f]"
+		cmd.Spec = "[-f] [--chart]"
 
 		ankhFilePath := cmd.StringOpt("f filename", "ankh.yaml", "Config file name")
+		chart := cmd.StringOpt("chart", "", "Limits the template command to only the specified chart")
 
 		cmd.Action = func() {
 			ctx.AnkhFilePath = *ankhFilePath
+			ctx.Chart = *chart
 
 			execute(ctx)
 			os.Exit(0)

--- a/src/ankh/helm/helm.go
+++ b/src/ankh/helm/helm.go
@@ -232,39 +232,34 @@ func createReducedYAMLFile(filename, key string) error {
 }
 
 func Template(ctx *ankh.ExecutionContext, ankhFile ankh.AnkhFile) (string, error) {
-	var err error
 	finalOutput := ""
-	isChartFlagged := ctx.Chart != ""
-
-	doTemplate := func(ctx *ankh.ExecutionContext, chart ankh.Chart, ankhFile ankh.AnkhFile, output string) (string, error) {
-		ctx.Logger.Debugf("templating chart '%s'", chart.Name)
-		chartOutput, err := templateChart(ctx, chart, ankhFile)
-		if err != nil {
-			return output, err
-		}
-		output += chartOutput
-		return output, nil
-	}
 
 	if len(ankhFile.Charts) > 0 {
 		ctx.Logger.Debugf("templating charts")
-		m := make(map[string]ankh.Chart, len(ankhFile.Charts))
-		for _, chart := range ankhFile.Charts {
-			m[chart.Name] = chart
-		}
-		if _, exists := m[ctx.Chart]; isChartFlagged && !exists {
+
+		if ctx.Chart == "" {
+			for _, chart := range ankhFile.Charts {
+				ctx.Logger.Debugf("templating chart '%s'", chart.Name)
+				chartOutput, err := templateChart(ctx, chart, ankhFile)
+				if err != nil {
+					return finalOutput, err
+				}
+				finalOutput += chartOutput
+			}
+		} else {
+			for _, chart := range ankhFile.Charts {
+				if chart.Name == ctx.Chart {
+					ctx.Logger.Debugf("templating chart '%s'", chart.Name)
+
+					chartOutput, err := templateChart(ctx, chart, ankhFile)
+					if err != nil {
+						return finalOutput, err
+					}
+					return chartOutput, nil
+				}
+			}
 			ctx.Logger.Fatalf("Chart %s was specified with `--chart` but does not exist in the charts array", ctx.Chart)
 		}
-		// if --chart is specified, just template that chart from the map
-		if isChartFlagged {
-			return doTemplate(ctx, m[ctx.Chart], ankhFile, finalOutput)
-		} else {
-			// otherwise template all the charts in the map
-			for _, chart := range m {
-				finalOutput, err = doTemplate(ctx, chart, ankhFile, finalOutput)
-			}
-		}
 	}
-
-	return finalOutput, err
+	return finalOutput, nil
 }


### PR DESCRIPTION
This allows you to run `template` or `apply` on just one specific chart in your ankh.yaml. It also adds validation to check if the charts array is empty. 

Open question for @esmet / @jondlm : 
The Python implementation allowed you to use either the name of the chart, the name of the chart directory, or the full .tgz filename of the packaged chart. Should we keep that API or just strip down to chart name? (which is what this current implementation does)