### PR TITLE
cmd line arg for helm --set values

### DIFF
--- a/src/ankh/ankh.go
+++ b/src/ankh/ankh.go
@@ -25,6 +25,7 @@ type ExecutionContext struct {
 	AnkhConfigPath string
 	KubeConfigPath string
 	DataDir        string
+	HelmSetValues  map[string]string
 
 	Logger *logrus.Logger
 }

--- a/src/ankh/helm/helm.go
+++ b/src/ankh/helm/helm.go
@@ -26,11 +26,20 @@ func templateChart(ctx *ankh.ExecutionContext, chart ankh.Chart, ankhFile ankh.A
 	// command for each item
 	if currentContext.Global != nil {
 		for _, item := range util.Collapse(currentContext.Global, nil, nil) {
-			helmArgs = append(helmArgs, "--set", "global."+item)
+			k := strings.Split(item, "=")
+			if _, inMap := ctx.HelmSetValues[k[0]]; inMap {
+				ctx.Logger.Debugf("Overriding ankh config global value %v with value supplied to command line", k[0])
+			} else {
+				helmArgs = append(helmArgs, "--set", "global."+item)
+			}
 		}
 	}
 
+	for key, val := range ctx.HelmSetValues {
+		helmArgs = append(helmArgs, "--set", "global."+key+"="+val)
+	}
 	files, err := ankh.FindChartFiles(ctx, ankhFile, chart)
+
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`ankh --set my.key.here=blah --set other.key.here=yey CMD [OPTIONS]`
will then pass the values to helm
`helm --set globel.my.key.here=blah --set global.other.key.here=yey ....`
basically the equivalent of setting global values in the ankh config.
also values set on the cmd line will override those in ankh config globals
