### PR TITLE
ensure chart version appears in notification messages

### DIFF
--- a/ankh/execute.go
+++ b/ankh/execute.go
@@ -413,7 +413,7 @@ func execute(ctx *ankh.ExecutionContext) {
 	}
 
 	if ctx.CreateJiraTicket {
-		if err := jira.CreateJiraTicket(ctx); err != nil {
+		if err := jira.CreateJiraTicket(ctx, &rootAnkhFile); err != nil {
 			ctx.Logger.Errorf("Unable to create JIRA ticket. %v", err)
 		}
 	}

--- a/ankh/execute.go
+++ b/ankh/execute.go
@@ -407,7 +407,7 @@ func execute(ctx *ankh.ExecutionContext) {
 	}
 
 	if ctx.SlackChannel != "" {
-		if err := slack.PingSlackChannel(ctx); err != nil {
+		if err := slack.PingSlackChannel(ctx, &rootAnkhFile); err != nil {
 			ctx.Logger.Errorf("Slack message failed with error: %v", err)
 		}
 	}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -149,10 +149,13 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 		format = ctx.AnkhConfig.Jira.RollbackSummaryFormat
 	}
 
-	chartName := fmt.Sprintf("%v@%v", chart.Name, chart.Version)
+	chartString, err := util.GetChartString(chart)
+	if err != nil {
+		return "", err
+	}
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartName, *chart.Tag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartString, *chart.Tag, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for subject", format)
 		} else {
@@ -161,7 +164,7 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForSummary(chartName, *chart.Tag, envOrContext)
+	message, err := promptForSummary(chartString, *chart.Tag, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for subject. Will use default subject")
 	}
@@ -176,10 +179,13 @@ func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 		format = ctx.AnkhConfig.Jira.RollbackDescriptionFormat
 	}
 
-	chartName := fmt.Sprintf("%v@%v", chart.Name, chart.Version)
+	chartString, err := util.GetChartString(chart)
+	if err != nil {
+		return "", err
+	}
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartName, *chart.Tag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartString, *chart.Tag, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for description", format)
 		} else {
@@ -188,7 +194,7 @@ func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForDescription(chartName, *chart.Tag, envOrContext)
+	message, err := promptForDescription(chartString, *chart.Tag, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for description. Will use default description")
 	}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -133,7 +133,7 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 	chartName := fmt.Sprintf("%v@%v", chart.Name, chart.Version)
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartName, ctx.DeploymentTag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartName, *chart.Tag, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for subject", format)
 		} else {
@@ -142,7 +142,7 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForSummary(chartName, ctx.DeploymentTag, envOrContext)
+	message, err := promptForSummary(chartName, *chart.Tag, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for subject. Will use default subject")
 	}
@@ -153,14 +153,14 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext string) (string, error) {
 	// If format is set, use that
 	format := ctx.AnkhConfig.Jira.DescriptionFormat
-	if ctx.DeploymentTag == "rollback" {
+	if *chart.Tag == "rollback" {
 		format = ctx.AnkhConfig.Jira.RollbackDescriptionFormat
 	}
 
 	chartName := fmt.Sprintf("%v@%v", chart.Name, chart.Version)
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartName, ctx.DeploymentTag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartName, *chart.Tag, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for description", format)
 		} else {
@@ -169,7 +169,7 @@ func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForDescription(chartName, ctx.DeploymentTag, envOrContext)
+	message, err := promptForDescription(chartName, *chart.Tag, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for description. Will use default description")
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -52,12 +52,12 @@ func PingSlackChannel(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) error
 		Username: username,
 	}
 
-	channelId, err := getSlackChannelIDByName(api, ctx.SlackChannel)
-	if err != nil {
-		return err
-	}
-
 	if !ctx.DryRun {
+		channelId, err := getSlackChannelIDByName(api, ctx.SlackChannel)
+		if err != nil {
+			return err
+		}
+
 		_, _, err = api.PostMessage(channelId, slack.MsgOptionAttachments(attachment), slack.MsgOptionPostMessageParameters(messageParams))
 	} else {
 		ctx.Logger.Infof("--dry-run set so not sending message '%v' to slack channel %v", messageText, ctx.SlackChannel)

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -125,10 +125,13 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 		format = ctx.AnkhConfig.Slack.RollbackFormat
 	}
 
-	chartName := fmt.Sprintf("%v@%v", chart.Name, chart.Version)
+	chartString, err := util.GetChartString(chart)
+	if err != nil {
+		return "", err
+	}
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartName, *chart.Tag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartString, *chart.Tag, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for message", format)
 		} else {
@@ -137,7 +140,7 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForMessageText(chartName, *chart.Tag, envOrContext)
+	message, err := promptForMessageText(chartString, *chart.Tag, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for message. Will use default message")
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -117,7 +117,7 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	chartName := fmt.Sprintf("%v@%v", chart.Name, chart.Version)
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartName, ctx.DeploymentTag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartName, *chart.Tag, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for message", format)
 		} else {
@@ -126,7 +126,7 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForMessageText(chartName, ctx.DeploymentTag, envOrContext)
+	message, err := promptForMessageText(chartName, *chart.Tag, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for message. Will use default message")
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -28,8 +28,7 @@ func PingSlackChannel(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) error
 		chart := &ankhFile.Charts[i]
 		message, err := getMessageText(ctx, chart, envOrContext)
 		if err != nil {
-			ctx.Logger.Infof("Unable to prompt for slack message. Using default value. Error: %v", err)
-			return err
+			return fmt.Errorf("Unable to prompt for slack message. Using default value. Error: %v", err)
 		} else {
 			messages = append(messages, message)
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -621,11 +621,16 @@ func GetEnvironmentOrContext(environment string, context string) string {
 	return ""
 }
 
-func GetAppVersion(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) string {
-
-	chart := &ankhFile.Charts[0]
-
-	return *chart.Tag
+func GetChartString(chart *ankh.Chart) (string, error) {
+	if chart.Path != "" {
+		absChartPath, err := filepath.Abs(chart.Path)
+		if err != nil {
+			return "", nil
+		}
+		return fmt.Sprintf("%v (local)", absChartPath), nil
+	} else {
+		return fmt.Sprintf("%v@%v", chart.Name, chart.Version), nil
+	}
 }
 
 func ReplaceFormatVariables(format string, chart string, version string, env string) (string, error) {


### PR DESCRIPTION
There's a bug with the `-s`/`--slack` and `-j`/`--jira-ticket` notifications where the notification message is interpolated with `ExecutionContext.Chart`, which is just verbatim text from the command line `--chart` argument (which could just be e.g. `foo` instead of `foo@1.2.3`).

This pull request fixes the bug so that instead of `ExecutionContext.Chart`, `AnkhFile.Charts -> Name` and `AnkhFile.Charts -> Version` are used to ensure the notification is consistent whether chart version is passed in from the command line argument or selected in the interactive prompt.

Some examples:

```sh
$ ./ankh/ankh -e rc apply --chart hbapi -s web-services-platform --dry-run
INFO    --dry-run set so not sending message '_rcousineau_ is releasing hbapi@0.1.58 version:1.18.1198 to *rc*' to slack channel web-services-platform
```

```sh
$ ./ankh/ankh -e rc apply --chart hbapi -j --dry-run
INFO    --dry-run set, not creating JIRA Ticket for CM queue with summary 'Deploy hbapi@0.1.58 version:1.18.1198 to rc' and description 'Ticket to track the deployment of *hbapi@0.1.58* version:1.18.1198 to *rc*'
```

```sh
$ ./ankh/ankh -e rc apply --ankhfile docs/sample-multi-chart-ankh.yaml -s rcousineau --dry-run
INFO    --dry-run set so not sending message '_rcousineau_ is releasing hbapi@0.1.58 version:1.18.1198 to *rc*
_rcousineau_ is releasing api@0.1.52 version:1.18.1198 to *rc*' to slack channel rcousineau
```

```sh
$ ./ankh/ankh -e rc apply --ankhfile docs/sample-multi-chart-ankh.yaml -j --dry-run
INFO    --dry-run set, not creating JIRA Ticket for CM queue with summary 'Deploy hbapi@0.1.58 version:1.18.1199 to rc
Deploy api@0.1.52 version:1.18.1199 to rc' and description 'Ticket to track the deployment of *hbapi@0.1.58* version:1.18.1199 to *rc*
Ticket to track the deployment of *api@0.1.52* version:1.18.1199 to *rc*'
```
