### PR TITLE
fix nil pointer dereference of `*chart.Tag`

### DIFF
--- a/jira/jira.go
+++ b/jira/jira.go
@@ -154,8 +154,13 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 		return "", err
 	}
 
+	versionString := ""
+	if chart.Tag != nil {
+		versionString = *chart.Tag
+	}
+
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartString, *chart.Tag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartString, versionString, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for subject", format)
 		} else {
@@ -164,7 +169,7 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForSummary(chartString, *chart.Tag, envOrContext)
+	message, err := promptForSummary(chartString, versionString, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for subject. Will use default subject")
 	}
@@ -173,9 +178,14 @@ func getSummary(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext stri
 }
 
 func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext string) (string, error) {
+	versionString := ""
+	if chart.Tag != nil {
+		versionString = *chart.Tag
+	}
+
 	// If format is set, use that
 	format := ctx.AnkhConfig.Jira.DescriptionFormat
-	if *chart.Tag == "rollback" {
+	if versionString == "rollback" {
 		format = ctx.AnkhConfig.Jira.RollbackDescriptionFormat
 	}
 
@@ -185,7 +195,7 @@ func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartString, *chart.Tag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartString, versionString, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for description", format)
 		} else {
@@ -194,7 +204,7 @@ func getDescription(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForDescription(chartString, *chart.Tag, envOrContext)
+	message, err := promptForDescription(chartString, versionString, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for description. Will use default description")
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -124,13 +124,18 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 		format = ctx.AnkhConfig.Slack.RollbackFormat
 	}
 
+	versionString := ""
+	if chart.Tag != nil {
+		versionString = *chart.Tag
+	}
+
 	chartString, err := util.GetChartString(chart)
 	if err != nil {
 		return "", err
 	}
 
 	if format != "" {
-		message, err := util.ReplaceFormatVariables(format, chartString, *chart.Tag, envOrContext)
+		message, err := util.ReplaceFormatVariables(format, chartString, versionString, envOrContext)
 		if err != nil {
 			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for message", format)
 		} else {
@@ -139,7 +144,7 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	}
 
 	// Otherwise, prompt for message
-	message, err := promptForMessageText(chartString, *chart.Tag, envOrContext)
+	message, err := promptForMessageText(chartString, versionString, envOrContext)
 	if err != nil {
 		ctx.Logger.Infof("Unable to prompt for message. Will use default message")
 	}


### PR DESCRIPTION
check if chart.Tag nil

prevent this error:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13f318f]
```