### PR TITLE
Add Helm 2 warning + add TODO for v2 support removal

### DIFF
--- a/ankh/execute.go
+++ b/ankh/execute.go
@@ -491,6 +491,7 @@ func executeAnkhFile(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) {
 		// because Tiller and the "client" distinction was removed in Helm 3+.
 		if strings.HasPrefix(trimmed, "Client: ") {
 			ctx.HelmV2 = true
+			ctx.Logger.Warnf("Helm v2 is no longer maintained as of November 2020, please migrate to Helm v3.\n Info here: https://helm.sh/docs/intro/install/")
 		}
 	}
 

--- a/helm/templatestage.go
+++ b/helm/templatestage.go
@@ -237,7 +237,8 @@ func templateChart(ctx *ankh.ExecutionContext, chart ankh.Chart, namespace strin
 	}
 
 	if currentContext.Release != "" {
-		// Helm 2 used `--name` to set release nam. Starting in Helm 3, this is a _positional_ argument.
+		// Helm 2 used `--name` to set release name. Starting in Helm 3, this is a _positional_ argument.
+		// TODO: Remove HelmV2 logic when support fully dropped
 		if ctx.HelmV2 {
 			helmArgs = append(helmArgs, []string{"--name", currentContext.Release}...)
 		} else {


### PR DESCRIPTION
Adding a warning for utilizing helm v2 given the loss of security patches as of November 2020 along with a TODO to drop v2 support in a future date.