### PR TITLE
Filter out image tags and chart versions

### DIFF
--- a/ankh/execute.go
+++ b/ankh/execute.go
@@ -103,7 +103,9 @@ func reconcileMissingConfigs(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile
 				return err
 			}
 
-			selectedVersion, err := util.PromptForSelection(strings.Split(strings.Trim(versions, "\n "), "\n"),
+			versionsList := util.FilterStringsContaining(strings.Split(strings.Trim(versions, "\n "), "\n"), ctx.ChartVersionFilter)
+
+			selectedVersion, err := util.PromptForSelection(versionsList,
 				fmt.Sprintf("Select a version for chart \"%v\"", chart.Name), false)
 			if err != nil {
 				return err

--- a/ankh/main.go
+++ b/ankh/main.go
@@ -305,7 +305,7 @@ func main() {
 	}
 
 	app.Command("apply", "Apply one or more charts to Kubernetes", func(cmd *cli.Cmd) {
-		cmd.Spec = "[--ankhfile] [--dry-run] [--chart] [--chart-path] [--slack] [--slack-message] [--jira-ticket] [--filter...]"
+		cmd.Spec = "[--ankhfile] [--dry-run] [--chart] [--chart-path] [--slack] [--slack-message] [--jira-ticket] [--filter...] [--image-tag-filter] [--chart-version-filter]"
 
 		ankhFilePath := cmd.StringOpt("ankhfile", "", "Path to an Ankh file for managing multiple charts")
 		dryRun := cmd.BoolOpt("dry-run", false, "Perform a dry-run and don't actually apply anything")
@@ -315,6 +315,8 @@ func main() {
 		slackMessageOverride := cmd.StringOpt("m slack-message", "", "Override the default slack message being sent")
 		createJiraTicket := cmd.BoolOpt("j jira-ticket", false, "Create a JIRA ticket to track update")
 		filter := cmd.StringsOpt("filter", []string{}, "Kubernetes object kinds to include for the action. The entries in this list are case insensitive. Any object whose `kind:` does not match this filter will be excluded from the action")
+		imageTagFilter := cmd.StringOpt("image-tag-filter", "", "Filters out any image tags that include the specified substring. Matching tags will not appear in the prompt.")
+		chartVersionFilter := cmd.StringOpt("chart-version-filter", "", "Filters out any chart versions that include the specified substring. Matching versions will not appear in the prompt.")
 
 		cmd.Action = func() {
 			ctx.AnkhFilePath = *ankhFilePath
@@ -333,6 +335,8 @@ func main() {
 				filters = append(filters, string(filter))
 			}
 			ctx.Filters = filters
+			ctx.ImageTagFilter = *imageTagFilter
+			ctx.ChartVersionFilter = *chartVersionFilter
 
 			execute(ctx)
 			os.Exit(0)

--- a/context/context.go
+++ b/context/context.go
@@ -64,6 +64,9 @@ type ExecutionContext struct {
 
 	Filters []string
 
+	ImageTagFilter     string
+	ChartVersionFilter string
+
 	ExtraArgs, PassThroughArgs []string
 
 	HelmVersion, KubectlVersion string

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -109,6 +109,8 @@ func listTags(ctx *ankh.ExecutionContext, r *registry.Registry,
 		return []string{}, nil
 	}
 
+	tags = util.FilterStringsContaining(tags, ctx.ImageTagFilter)
+
 	sort.Slice(tags, func(i, j int) bool {
 		lessThan := util.FuzzySemVerCompare(tags[i], tags[j])
 		if descending {

--- a/util/util.go
+++ b/util/util.go
@@ -689,3 +689,21 @@ func UpdateFile(filename string, newString string, oldString string) error {
 	}
 	return nil
 }
+
+// FilterStringsContaining filters out strings from stringSlice that contain the substring.
+func FilterStringsContaining(stringSlice []string, substring string) []string {
+	if len(substring) > 0 {
+		return FilterStrings(stringSlice, func(s string) bool { return !strings.Contains(s, substring) })
+	}
+	return stringSlice
+}
+
+// FilterStrings out based on matcher implementation.
+func FilterStrings(strings []string, matcher func(string) bool) (ret []string) {
+	for _, s := range strings {
+		if matcher(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}


### PR DESCRIPTION
Adds options to filter our image tags and chart versions.

For example, when building image tags via Concourse, they're automatically pushed to our image hub (Artifactory). 
Which clutters up our versioning namespace when later attempting to deploy...

Currently:
<img width="649" alt="Screen Shot 2021-02-26 at 5 12 19 PM" src="https://user-images.githubusercontent.com/8150093/109360775-cb1a8c00-7855-11eb-8d4a-a7b17b07cc4a.png">

With current branch:
<img width="653" alt="Screen Shot 2021-02-26 at 5 13 37 PM" src="https://user-images.githubusercontent.com/8150093/109360892-f8ffd080-7855-11eb-9426-a59800a4ecc3.png">
