### PR TITLE
Add new formatting keys for jira/slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,10 +329,12 @@ When invoked, Ankh will operate over both the `haste-server` and `myservice` cha
 
 #### `Format Variables`
 | Variable | Description
-| ------------- | :---:    
-| `%USER%`        | Current username |
-| `%CHART%`       | Current chart being used |
-| `%VERSION%`     | Version of the primary container |
-| `%TARGET%`      | Target environment or context |
+| ------------- | :---:
+| `%USER%`          | Current username |
+| `%CHART%`         | Current chart being used (`<name>@<version>`) |
+| `%CHART_NAME%`    | Name of chart |
+| `%CHART_VERSION%` | Version of chart |
+| `%VERSION%`       | Version of the primary container |
+| `%TARGET%`        | Target environment or context |
 
- Example format: `format: "_%USER%_ is releasing *%CHART%@%VERSION%* to *%TARGET%*"`
+ Example format: `format: "_%USER%_ is releasing *%CHART_NAME%* chart:*%CHART_VERSION%* tag:*%VERSION%* to *%TARGET%*"`

--- a/util/util.go
+++ b/util/util.go
@@ -661,6 +661,44 @@ func ReplaceFormatVariables(format string, chart string, version string, env str
 	return result, nil
 }
 
+func NotificationString(notificationFormat string, chart *ankh.Chart, envOrContext string) (string, error) {
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	chartName := chart.Name
+	chartVersion := ""
+	chartString := ""
+	if chart.Path != "" {
+		absChartPath, err := filepath.Abs(chart.Path)
+		if err != nil {
+			return "", nil
+		}
+		chartVersion = fmt.Sprintf("%s (local)", absChartPath)
+		chartString = chartVersion
+	} else {
+		chartVersion = chart.Version
+		chartString = fmt.Sprintf("%s@%s", chartName, chartVersion)
+	}
+
+	version := ""
+	if chart.Tag != nil {
+		version = *chart.Tag
+	}
+
+	result := notificationFormat
+	result = strings.Replace(result, "%USER%", currentUser.Username, -1)
+	result = strings.Replace(result, "%CHART_NAME%", chartName, -1)
+	result = strings.Replace(result, "%CHART_VERSION%", chartVersion, -1)
+	result = strings.Replace(result, "%CHART%", chartString, -1)
+	result = strings.Replace(result, "%VERSION%", version, -1)
+	result = strings.Replace(result, "%TARGET%", envOrContext, -1)
+
+	return result, nil
+}
+
 // GenerateName generates a name based on the current working directory or a random name.
 func GenerateName(ctx *ankh.ExecutionContext, appName string) string {
 	if appName != "" {

--- a/util/util.go
+++ b/util/util.go
@@ -626,41 +626,6 @@ func GetEnvironmentOrContext(environment string, context string) string {
 	return ""
 }
 
-func GetChartString(chart *ankh.Chart) (string, error) {
-	if chart.Path != "" {
-		absChartPath, err := filepath.Abs(chart.Path)
-		if err != nil {
-			return "", nil
-		}
-		return fmt.Sprintf("%v (local)", absChartPath), nil
-	} else {
-		return fmt.Sprintf("%v@%v", chart.Name, chart.Version), nil
-	}
-}
-
-func ReplaceFormatVariables(format string, chart string, version string, env string) (string, error) {
-
-	result := format
-	currentUser, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	// Replace %USER%
-	result = strings.Replace(result, "%USER%", currentUser.Username, -1)
-
-	// Replace %CHART%
-	result = strings.Replace(result, "%CHART%", chart, -1)
-
-	// Replace %VERSION%
-	result = strings.Replace(result, "%VERSION%", version, -1)
-
-	// Replace %TARGET%
-	result = strings.Replace(result, "%TARGET%", env, -1)
-
-	return result, nil
-}
-
 func NotificationString(notificationFormat string, chart *ankh.Chart, envOrContext string) (string, error) {
 
 	currentUser, err := user.Current()

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"testing"
 
+	ankh "github.com/appnexus/ankh/context"
 	"github.com/sirupsen/logrus"
 )
 
@@ -140,6 +141,140 @@ func TestReplaceFormatVariables(t *testing.T) {
 
 	expectedResult = "Someone is doing a release of %CHAT% version 1.33.7 to production"
 	result, err = ReplaceFormatVariables(format, chart, version, env)
+	if err != nil {
+		t.Logf("Failed to replace message text. Error: %v", err)
+		t.Fail()
+	}
+	if result != expectedResult {
+		t.Logf("got %s but was expecting '%s'", result, expectedResult)
+		t.Fail()
+	}
+
+}
+
+func TestNotificationString(t *testing.T) {
+
+	// replace %USER%, %CHART%, %VERSION%, %TARGET% (non-local chart)
+
+	notificationFormat := "%USER% is doing a release of %CHART% version %VERSION% to %TARGET%"
+	version := "1.33.7"
+	chart := &ankh.Chart{
+		Path:    "",
+		Name:    "best app ever",
+		Version: "1.2.3",
+		Tag:     &version,
+	}
+	envOrContext := "production"
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Logf("Unable to get currnet user for test. Error: %v", err)
+		t.Fail()
+	}
+
+	expectedResult := fmt.Sprintf("%v is doing a release of best app ever@1.2.3 version 1.33.7 to production", currentUser.Username)
+	result, err := NotificationString(notificationFormat, chart, envOrContext)
+	if err != nil {
+		t.Logf("Failed to replace message text. Error: %v", err)
+		t.Fail()
+	}
+	if result != expectedResult {
+		t.Logf("got %s but was expecting '%s'", result, expectedResult)
+		t.Fail()
+	}
+
+	// -----------------------------------------------------------------
+
+	// replace %CHART%, %VERSION%, %TARGET% (local chart)
+
+	notificationFormat = "Releasing %CHART% version %VERSION% to %TARGET%"
+	version = "1.33.7"
+	chart = &ankh.Chart{
+		Path:    "/home/someone/app/helm/app",
+		Name:    "best app ever",
+		Version: "1.2.3",
+		Tag:     &version,
+	}
+	envOrContext = "production"
+
+	expectedResult = "Releasing /home/someone/app/helm/app (local) version 1.33.7 to production"
+	result, err = NotificationString(notificationFormat, chart, envOrContext)
+	if err != nil {
+		t.Logf("Failed to replace message text. Error: %v", err)
+		t.Fail()
+	}
+	if result != expectedResult {
+		t.Logf("got %s but was expecting '%s'", result, expectedResult)
+		t.Fail()
+	}
+
+	// -----------------------------------------------------------------
+
+	// replace %CHART_NAME%, %CHART_VERSION%, %VERSION%, %TARGET% (non-local chart)
+
+	notificationFormat = "Releasing %CHART_NAME% chart %CHART_VERSION% version %VERSION% to %TARGET%"
+	version = "1.33.7"
+	chart = &ankh.Chart{
+		Path:    "",
+		Name:    "best app ever",
+		Version: "1.2.3",
+		Tag:     &version,
+	}
+	envOrContext = "production"
+
+	expectedResult = "Releasing best app ever chart 1.2.3 version 1.33.7 to production"
+	result, err = NotificationString(notificationFormat, chart, envOrContext)
+	if err != nil {
+		t.Logf("Failed to replace message text. Error: %v", err)
+		t.Fail()
+	}
+	if result != expectedResult {
+		t.Logf("got %s but was expecting '%s'", result, expectedResult)
+		t.Fail()
+	}
+
+	// -----------------------------------------------------------------
+
+	// replace %CHART_NAME%, %CHART_VERSION%, %VERSION%, %TARGET% (local chart)
+
+	notificationFormat = "Releasing %CHART_NAME% chart %CHART_VERSION% version %VERSION% to %TARGET%"
+	version = "1.33.7"
+	chart = &ankh.Chart{
+		Path:    "/home/someone/app/helm/app",
+		Name:    "best app ever",
+		Version: "1.2.3",
+		Tag:     &version,
+	}
+	envOrContext = "production"
+
+	expectedResult = "Releasing best app ever chart /home/someone/app/helm/app (local) version 1.33.7 to production"
+	result, err = NotificationString(notificationFormat, chart, envOrContext)
+	if err != nil {
+		t.Logf("Failed to replace message text. Error: %v", err)
+		t.Fail()
+	}
+	if result != expectedResult {
+		t.Logf("got %s but was expecting '%s'", result, expectedResult)
+		t.Fail()
+	}
+
+	// -----------------------------------------------------------------
+
+	// replace %VERSION%, %TARGET (non-local chart)
+	// format also includes (typo?) %CHAT% which is not replaced
+
+	notificationFormat = "Releasing %CHAT% version %VERSION% to %TARGET%"
+	version = "1.33.7"
+	chart = &ankh.Chart{
+		Path:    "",
+		Name:    "best app ever",
+		Version: "1.2.3",
+		Tag:     &version,
+	}
+	envOrContext = "production"
+
+	expectedResult = "Releasing %CHAT% version 1.33.7 to production"
+	result, err = NotificationString(notificationFormat, chart, envOrContext)
 	if err != nil {
 		t.Logf("Failed to replace message text. Error: %v", err)
 		t.Fail()

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -110,48 +110,6 @@ func TestGetEnviroment(t *testing.T) {
 	}
 }
 
-func TestReplaceFormatVariables(t *testing.T) {
-
-	format := "%USER% is doing a release of %CHART% version %VERSION% to %TARGET%"
-	chart := "best app ever"
-	version := "1.33.7"
-	env := "production"
-
-	currentUser, err := user.Current()
-	if err != nil {
-		t.Logf("Unable to get currnet user for test. Error: %v", err)
-		t.Fail()
-	}
-
-	expectedResult := fmt.Sprintf("%v is doing a release of best app ever version 1.33.7 to production", currentUser.Username)
-	result, err := ReplaceFormatVariables(format, chart, version, env)
-	if err != nil {
-		t.Logf("Failed to replace message text. Error: %v", err)
-		t.Fail()
-	}
-	if result != expectedResult {
-		t.Logf("got %s but was expecting '%s'", result, expectedResult)
-		t.Fail()
-	}
-
-	format = "Someone is doing a release of %CHAT% version %VERSION% to %TARGET%"
-	chart = "best app ever"
-	version = "1.33.7"
-	env = "production"
-
-	expectedResult = "Someone is doing a release of %CHAT% version 1.33.7 to production"
-	result, err = ReplaceFormatVariables(format, chart, version, env)
-	if err != nil {
-		t.Logf("Failed to replace message text. Error: %v", err)
-		t.Fail()
-	}
-	if result != expectedResult {
-		t.Logf("got %s but was expecting '%s'", result, expectedResult)
-		t.Fail()
-	}
-
-}
-
 func TestNotificationString(t *testing.T) {
 
 	// replace %USER%, %CHART%, %VERSION%, %TARGET% (non-local chart)


### PR DESCRIPTION
This adds the keys `%CHART_NAME%` and `%CHART_VERSION%` for more fine-grained customization of notifications (if `%CHART%` which joins the name and version with a `@` is not desired)