### PR TITLE
[WSP-2779] Added  -r option to auto post rollback instruction on a release to Slack

### DIFF
--- a/ankh/main.go
+++ b/ankh/main.go
@@ -305,7 +305,7 @@ func main() {
 	}
 
 	app.Command("apply", "Apply one or more charts to Kubernetes", func(cmd *cli.Cmd) {
-		cmd.Spec = "[--ankhfile] [--dry-run] [--chart] [--chart-path] [--slack] [--slack-message] [--jira-ticket] [--filter...] [--image-tag-filter] [--chart-version-filter]"
+		cmd.Spec = "[--ankhfile] [--dry-run] [--chart] [--chart-path] [--slack] [--slack-message] [--rollback-instructions] [--jira-ticket] [--filter...] [--image-tag-filter] [--chart-version-filter]"
 
 		ankhFilePath := cmd.StringOpt("ankhfile", "", "Path to an Ankh file for managing multiple charts")
 		dryRun := cmd.BoolOpt("dry-run", false, "Perform a dry-run and don't actually apply anything")
@@ -313,6 +313,7 @@ func main() {
 		chartPath := cmd.StringOpt("chart-path", "", "Use a local chart directory instead of a remote, versioned chart")
 		slackChannel := cmd.StringOpt("s slack", "", "Send slack message to specified slack channel about application update")
 		slackMessageOverride := cmd.StringOpt("m slack-message", "", "Override the default slack message being sent")
+		rollbackInstructions := cmd.BoolOpt("r rollback-instructions", false, "Send rollback instructions to the specified slack channel")
 		createJiraTicket := cmd.BoolOpt("j jira-ticket", false, "Create a JIRA ticket to track update")
 		filter := cmd.StringsOpt("filter", []string{}, "Kubernetes object kinds to include for the action. The entries in this list are case insensitive. Any object whose `kind:` does not match this filter will be excluded from the action")
 		imageTagFilter := cmd.StringOpt("image-tag-filter", "", "Filters out any image tags that include the specified substring. Matching tags will not appear in the prompt.")
@@ -329,6 +330,7 @@ func main() {
 			ctx.Mode = ankh.Apply
 			ctx.SlackChannel = *slackChannel
 			ctx.SlackMessageOverride = *slackMessageOverride
+			ctx.RollbackInstructions = *rollbackInstructions
 			ctx.CreateJiraTicket = *createJiraTicket
 			filters := []string{}
 			for _, filter := range *filter {

--- a/context/context.go
+++ b/context/context.go
@@ -42,7 +42,7 @@ type ExecutionContext struct {
 
 	Mode Mode
 
-	Verbose, Quiet, ShouldCatchSignals, CatchSignals, DryRun, Describe, WarnOnConfigError,
+	Verbose, Quiet, ShouldCatchSignals, CatchSignals, DryRun, RollbackInstructions, Describe, WarnOnConfigError,
 	IgnoreContextAndEnv, IgnoreConfigErrors, SkipConfig, NoPrompt bool
 
 	WorkingPath    string
@@ -56,6 +56,8 @@ type ExecutionContext struct {
 	HelmDir        string
 
 	DeploymentTag string
+	RollbackChart string
+	RollbackTag   string
 
 	SlackChannel         string
 	SlackMessageOverride string

--- a/go.mod
+++ b/go.mod
@@ -1,31 +1,111 @@
 module github.com/appnexus/ankh
 
+go 1.17
+
 require (
-	github.com/alecthomas/gometalinter v2.0.12+incompatible // indirect
-	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/andygrunwald/go-jira v1.6.0
 	github.com/coreos/go-semver v0.2.0
-	github.com/docker/distribution v2.7.0-rc.0+incompatible // indirect
 	github.com/docker/docker v1.13.1
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/fatih/structs v1.1.0 // indirect
 	github.com/genuinetools/reg v0.16.0
-	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/imdario/mergo v0.0.0-20181107191138-ca3dcc1022ba
 	github.com/jawher/mow.cli v1.0.3
 	github.com/manifoldco/promptui v0.3.2
 	github.com/mattn/go-isatty v0.0.4
-	github.com/nicksnyder/go-i18n v1.10.0 // indirect
 	github.com/nlopes/slack v0.0.0-20190117134835-3b9e5d653ede
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/pelletier/go-toml v1.2.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.0.6
 	github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245
-	github.com/trivago/tgo v1.0.5 // indirect
-	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 	gopkg.in/yaml.v2 v2.2.1
+)
+
+require (
+	cloud.google.com/go v0.26.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Microsoft/go-winio v0.4.11 // indirect
+	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
+	github.com/alecthomas/gometalinter v2.0.12+incompatible // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/client9/misspell v0.3.4 // indirect
+	github.com/containerd/continuity v0.0.0-20180921161001-7f53d412b9eb // indirect
+	github.com/coreos/clair v0.0.0-20180919182544-44ae4bc9590a // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/cli v0.0.0-20180920165730-54c19e67f69c // indirect
+	github.com/docker/distribution v2.7.0-rc.0+incompatible // indirect
+	github.com/docker/docker-ce v0.0.0-20180924210327-f53bd8bb8e43 // indirect
+	github.com/docker/docker-credential-helpers v0.6.1 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916 // indirect
+	github.com/docker/go-units v0.3.3 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
+	github.com/fernet/fernet-go v0.0.0-20180830025343-9eac43b88a5e // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/genuinetools/pkg v0.0.0-20180910213200-1c141f661797 // indirect
+	github.com/gogo/protobuf v1.1.1 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
+	github.com/golang/mock v1.1.1 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/google/go-cmp v0.2.0 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
+	github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2 // indirect
+	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.5.0 // indirect
+	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/kr/pty v1.1.1 // indirect
+	github.com/kr/text v0.1.0 // indirect
+	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/nicksnyder/go-i18n v1.10.0 // indirect
+	github.com/onsi/ginkgo v1.6.0 // indirect
+	github.com/onsi/gomega v1.4.2 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/peterhellberg/link v1.0.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v0.0.0-20180924113449-f69c853d21c1 // indirect
+	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
+	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e // indirect
+	github.com/prometheus/procfs v0.0.0-20180920065004-418d78d0b9a7 // indirect
+	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
+	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/trivago/tgo v1.0.5 // indirect
+	github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
+	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
+	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
+	golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f // indirect
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
+	google.golang.org/appengine v1.1.0 // indirect
+	google.golang.org/genproto v0.0.0-20180924164928-221a8d4f7494 // indirect
+	google.golang.org/grpc v1.15.0 // indirect
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gotest.tools v2.1.0+incompatible // indirect
+	honnef.co/go/tools v0.0.0-20180728063816-88497007e858 // indirect
 )
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y8QwKX5HZymrMz2IiKFc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -149,6 +150,7 @@ golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181122213734-04b5d21e00f1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181218194233-bbbd9518e88c h1:U6o/rhnoGxB5KVfjINfppfrvpIuKoe4GFC6ypUlduvQ=
 golang.org/x/tools v0.0.0-20181218194233-bbbd9518e88c/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f h1:kDxGY2VmgABOe55qheT/TFqUMtcTHnomIPS1iv3G4Ms=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/kubectl/getchartandtagstage.go
+++ b/kubectl/getchartandtagstage.go
@@ -1,0 +1,43 @@
+package kubectl
+
+import (
+	"github.com/appnexus/ankh/context"
+	"github.com/appnexus/ankh/plan"
+)
+
+type GetChartTagStage struct {
+	GenericStage
+}
+
+func NewGetChartTagStage() plan.Stage {
+	return &KubectlRunner{kubectl: &GetChartTagStage{}}
+}
+
+func (stage *GetChartTagStage) GetCommand(ctx *ankh.ExecutionContext, namespace string) plan.Command {
+	cmd := newKubectlCommand(ctx, namespace)
+	cmd.AddArguments([]string{"get", "pods"})
+
+	// We want to stream logs to stdout/stderr, since it may be watched via `-w`.
+	cmd.PipeStdoutAndStderr = plan.PIPE_TYPE_PIPE
+	return cmd
+}
+
+func (stage *GetChartTagStage) GetArgsFromInput(ctx *ankh.ExecutionContext, input string, wildCardLabels []string) ([]string, error) {
+	// Add selector args
+	selectorArgs, err := getPodSelectorArgsFromInput(ctx, input)
+	if err != nil {
+		return []string{}, err
+	}
+	selectorArgs = append(selectorArgs, getWildCardLabels(ctx, wildCardLabels)...)
+
+	return selectorArgs, nil
+}
+
+func (stage *GetChartTagStage) GetFinalArgs(ctx *ankh.ExecutionContext) []string {
+	args := ctx.ExtraArgs
+	if len(ctx.PassThroughArgs) > 0 {
+		passThroughArgs := append([]string{"--"}, ctx.PassThroughArgs...)
+		args = append(args, passThroughArgs...)
+	}
+	return args
+}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -24,8 +24,20 @@ func PingSlackChannel(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) error
 	envOrContext := util.GetEnvironmentOrContext(ctx.Environment, ctx.Context)
 
 	var messages []string
+	var rollbackInstructionMessages []string
+
 	for i := 0; i < len(ankhFile.Charts); i++ {
 		chart := &ankhFile.Charts[i]
+
+		if ctx.RollbackInstructions {
+			rollbackInstructionMessage, err := getRollbackMessageText(ctx, chart, envOrContext)
+			if err != nil {
+				return fmt.Errorf("Unable to prompt for rollback slack message. Using default value. Error: %v", err)
+			} else {
+				rollbackInstructionMessages = append(rollbackInstructionMessages, rollbackInstructionMessage)
+			}
+		}
+
 		message, err := getMessageText(ctx, chart, envOrContext)
 		if err != nil {
 			return fmt.Errorf("Unable to prompt for slack message. Using default value. Error: %v", err)
@@ -34,16 +46,25 @@ func PingSlackChannel(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) error
 		}
 	}
 	messageText := strings.Join(messages, "\n")
+	rollbackInstuctionMessageText := strings.Join(rollbackInstructionMessages, "\n")
 
 	pretext := ctx.AnkhConfig.Slack.Pretext
 	if pretext == "" {
 		pretext = "A new release notification has been received"
 	}
 
+	rollbackInstructionPretext := "Rollback Information for the above release"
+
 	attachment := slack.Attachment{
 		Color:   "good",
 		Pretext: pretext,
 		Text:    messageText,
+	}
+
+	rollbackInstructionAttachment := slack.Attachment{
+		Color:   "good",
+		Pretext: rollbackInstructionPretext,
+		Text:    rollbackInstuctionMessageText,
 	}
 
 	icon := DEFAULT_ICON_URL
@@ -68,6 +89,9 @@ func PingSlackChannel(ctx *ankh.ExecutionContext, ankhFile *ankh.AnkhFile) error
 		}
 
 		_, _, err = api.PostMessage(channelId, slack.MsgOptionAttachments(attachment), slack.MsgOptionPostMessageParameters(messageParams))
+		if ctx.RollbackInstructions {
+			_, _, err = api.PostMessage(channelId, slack.MsgOptionAttachments(rollbackInstructionAttachment), slack.MsgOptionPostMessageParameters(messageParams))
+		}
 		return err
 	} else {
 		ctx.Logger.Infof("--dry-run set so not sending message '%v' to slack channel %v", messageText, ctx.SlackChannel)
@@ -142,6 +166,36 @@ func getMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext 
 	return message, nil
 }
 
+func getRollbackMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext string) (string, error) {
+
+	var rollbackChart ankh.Chart
+	rollbackChart = *chart
+	rollbackChart.Name = strings.Split(ctx.RollbackChart, "-")[0]
+	rollbackChart.Version = strings.Split(ctx.RollbackChart, "-")[1]
+	rollbackChart.Tag = &ctx.RollbackTag
+	rollbackChart.Path = ""
+
+	// If format is set, use that
+	format := "chart: %CHART_NAME% version:%CHART_VERSION% tag: %VERSION% environment: %TARGET%"
+
+	if format != "" {
+		message, err := util.RollbackInstructionNotificationString(format, &rollbackChart, envOrContext)
+		if err != nil {
+			ctx.Logger.Infof("Unable to use format: '%v'. Will prompt for message", format)
+		} else {
+			return message, nil
+		}
+	}
+
+	// Otherwise, prompt for message
+	message, err := promptForRollbackInstructionMessageText(&rollbackChart, envOrContext)
+	if err != nil {
+		ctx.Logger.Infof("Unable to prompt for rollback instructionmessage. Will use default message")
+	}
+
+	return message, nil
+}
+
 func promptForMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrContext string) (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
@@ -157,6 +211,23 @@ func promptForMessageText(ctx *ankh.ExecutionContext, chart *ankh.Chart, envOrCo
 	if ctx.Mode == ankh.Rollback {
 		defaultMessage = fmt.Sprintf("%s is rolling back %s in *%v*", currentUser, chart.Name, envOrContext)
 	}
+
+	message, err := util.PromptForInput(defaultMessage, "Slack Message")
+	if err != nil {
+		return defaultMessage, err
+	}
+
+	return message, nil
+}
+
+func promptForRollbackInstructionMessageText(chart *ankh.Chart, envOrContext string) (string, error) {
+
+	version := ""
+	if chart.Tag != nil {
+		version = *chart.Tag
+	}
+
+	defaultMessage := fmt.Sprintf("Rollback Information %s chart %s version %s to *%s*", chart.Name, chart.Version, version, envOrContext)
 
 	message, err := util.PromptForInput(defaultMessage, "Slack Message")
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -664,6 +664,44 @@ func NotificationString(notificationFormat string, chart *ankh.Chart, envOrConte
 	return result, nil
 }
 
+func RollbackInstructionNotificationString(notificationFormat string, chart *ankh.Chart, envOrContext string) (string, error) {
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	chartName := chart.Name
+	chartVersion := ""
+	chartString := ""
+	if chart.Path != "" {
+		absChartPath, err := filepath.Abs(chart.Path)
+		if err != nil {
+			return "", nil
+		}
+		chartVersion = fmt.Sprintf("%s (local)", absChartPath)
+		chartString = chartVersion
+	} else {
+		chartVersion = chart.Version
+		chartString = fmt.Sprintf("%s@%s", chartName, chartVersion)
+	}
+
+	version := ""
+	if chart.Tag != nil {
+		version = *chart.Tag
+	}
+
+	result := notificationFormat
+	result = strings.Replace(result, "%USER%", currentUser.Username, -1)
+	result = strings.Replace(result, "%CHART_NAME%", chartName, -1)
+	result = strings.Replace(result, "%CHART_VERSION%", chartVersion, -1)
+	result = strings.Replace(result, "%CHART%", chartString, -1)
+	result = strings.Replace(result, "%VERSION%", version, -1)
+	result = strings.Replace(result, "%TARGET%", envOrContext, -1)
+
+	return result, nil
+}
+
 // GenerateName generates a name based on the current working directory or a random name.
 func GenerateName(ctx *ankh.ExecutionContext, appName string) string {
 	if appName != "" {


### PR DESCRIPTION
Added a -r or --rolback-instructions option to ankh apply which will post rollback instructions to slack on a new release. 

Test - 

example command - ankh -e wspteam  apply --chart hbapi@0.1.235 -s test-ns7860 -r

<img width="715" alt="image" src="https://user-images.githubusercontent.com/67106007/167890651-0ce0a982-9fc8-45b5-9e86-333f7f0f7e49.png">
